### PR TITLE
ci: enforce PR hygiene and linting rules

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,12 @@
-## Description
-Please include a summary of the change and which issue is fixed.
+### Summary
+<!-- Describe the changes in this PR. Be clear and concise. -->
 
-## Type of change
+### Related issues
+<!-- Mention any related issues here. Use "Closes #N" to auto-close an issue, or "no issue" if this PR is standalone. -->
+Closes #
+
+### Testing Done
+<!-- Briefly describe how you tested these changes. -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,24 @@
+name: PR Lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  pr-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify PR Body Content
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const body = context.payload.pull_request.body || "";
+            const issueRegex = /(Closes #\d+|no issue)/i;
+            
+            if (!issueRegex.test(body)) {
+              core.setFailed("PR body must include a 'Related issues' section with 'Closes #N' or 'no issue'.");
+            }
+            
+            if (body.length < 20) {
+              core.setFailed("PR body must contain a meaningful summary.");
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,11 +3,12 @@
 We love your input! We want to make contributing to this project as easy and transparent as possible.
 
 ## Pull Requests
-1. Fork the repo and create your branch from `main`.
-2. If you've added code that should be tested, add tests.
-3. Ensure the test suite passes.
-4. Make sure your code lints.
-5. Issue that pull request!
+
+1. **Create a branch**: Branch off from `master` for your work.
+2. **Commit changes**: Keep your commits focused and provide clear messages.
+3. **Open a PR**: Fill out the Pull Request template completely.
+4. **Required Formatting**: Your PR description **must** contain a clear summary and a "Related issues" section stating either `Closes #N` or `no issue`. Our CI (`pr-lint`) will reject the PR if this is missing.
+5. **CI Checks**: Ensure all tests, linter checks, and coverage gates pass before requesting review.
 
 ## Code of Conduct
 Please note that this project is released with a Contributor Code of Conduct. By participating in this project you agree to abide by its terms.


### PR DESCRIPTION
### Summary
Added a new GitHub action to strictly enforce PR body content according to our new code of conduct standards. Also updated the PR template and CONTRIBUTING.md instructions.

### Related issues
no issue